### PR TITLE
Fix user profiles

### DIFF
--- a/snippets/modals.css
+++ b/snippets/modals.css
@@ -16,8 +16,8 @@ other contributors to USRBG.
 .root-SR8cQa {
   transform: translateZ(0);
 }
-.header-QKLPzZ .wrapper-3t9DeA::before {
-  content: '';
+#app-mount .header-QKLPzZ .wrapper-3t9DeA::before {
+  content: '' !important;
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
Profile modals broke due to CSS scoping stuff and conflicts with Discord's styles, this fixes that and profiles have backgrounds again.