### PR TITLE
Fix popout positioning issues

### DIFF
--- a/snippets/userPopouts.css
+++ b/snippets/userPopouts.css
@@ -18,8 +18,8 @@ other contributors to USRBG.
 .userPopout-3XzG_A .wrapper-3t9DeA::after {
 	content: '';
 	position: fixed;
-	top: 0;
-	left: 0;
+	top: 0 !important;
+	left: 0 !important;
 	width: 100%;
 	height: 100%;
 	z-index: -1;


### PR DESCRIPTION
Fix issues with CSS scoping to break positioning.

Before: (pay attention to the left and top)
![image](https://user-images.githubusercontent.com/19270622/115091801-7d92d500-9f10-11eb-8021-047653c6f879.png)

After:
![image](https://user-images.githubusercontent.com/19270622/115091824-8edbe180-9f10-11eb-8808-ae0a0448f215.png)
