### PR TITLE
Dream Frame is dropping support in v6 (Remove it)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ This will import the USRBG database. Alone, it's simply some variables. Some of 
 * [Discord.tv](https://github.com/userMacieG/userMacieG.github.io/blob/master/betterdiscord/discord-tv.theme.css) by userMacieG
 * [DiscordDarkNeon](https://github.com/CommandCrafterHD/DiscordDarkNeon) by CommandCrafterHD
 * [DiscordNight](https://github.com/KillYoy/DiscordNight) by KillYoy
-* [Dream Frame](https://github.com/dream-frame/Dream-Frame) by Korbs and Creatable (unmaintained)
 * [Frosted Glass](https://github.com/DiscordStyles/FrostedGlass) by Gibbu
 * [LilyPichu](https://github.com/NYRI4/LilyPichu) by Nyria
 * [Midnight](https://tropix126.github.io/BetterDiscordStuff/midnight/) by Tropical (unmaintained)


### PR DESCRIPTION
Plans for Dream Frame v6.0.0 will involve usrbg support being dropped, of course this has to do with Powercord. 